### PR TITLE
fixed gulpbabel file name capitalisation  

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,2 +1,2 @@
 require('babel-core/register');
-require('./gulpfile.babel.js');
+require('./Gulpfile.babel.js');


### PR DESCRIPTION
the gulp command could't run due to capitalised file name. fixed and working.
